### PR TITLE
Add concurrent proxy filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# proxy-1
+# Proxy Quality Checker
+
+Esta aplicación permite analizar listas de proxies para determinar su calidad.
+Incluye una interfaz gráfica opcional y un modo de consola para entornos sin
+display. Los proxies se verifican en paralelo y solo se muestran los que están
+activos y no aparecen en listas negras.
+
+## Requisitos
+
+Instala las dependencias con:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Uso en modo consola
+
+```bash
+python proxy_quality_checker.py --file lista.txt
+```
+
+Donde `lista.txt` es un archivo con proxies en formato `IP:PUERTO[:tipo]`.
+
+## Uso de la interfaz gráfica
+
+Si cuentas con un entorno con pantalla puedes ejecutar simplemente:
+
+```bash
+python proxy_quality_checker.py
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 Esta aplicación permite analizar listas de proxies para determinar su calidad.
 Incluye una interfaz gráfica opcional y un modo de consola para entornos sin
 display. Los proxies se verifican en paralelo y solo se muestran los que están
-activos y no aparecen en listas negras.
+activos y no aparecen en listas negras. Carga la lista desde un archivo y
+presiona **Analizar proxies** para ejecutar todas las comprobaciones.
 
 ## Requisitos
 
@@ -28,3 +29,8 @@ Si cuentas con un entorno con pantalla puedes ejecutar simplemente:
 ```bash
 python proxy_quality_checker.py
 ```
+
+Tras cargar un archivo de proxies con el botón **Cargar archivo de proxies**, la
+lista se almacena en la aplicación. Pulsa **Analizar proxies** para realizar las
+comprobaciones de conectividad y listas negras y mostrar solo los proxies
+válidos.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+dnspython


### PR DESCRIPTION
## Summary
- auto-detect proxy type when loading files
- verify proxies concurrently and filter dead or blacklisted ones
- update CLI to use concurrent verification
- document parallel filtering behavior in Spanish README

## Testing
- `python -m py_compile proxy_quality_checker.py`
- `python proxy_quality_checker.py --file requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6848d806c2608320adc870a09ee69be2